### PR TITLE
Update to follow React-Native best practices

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export default class Dots extends Component {
     activeBorderColor: "#FFF"
   };
 
-  componentDidUpdate (prevProps, prevState, snapshot) {
+  componentDidUpdate (prevProps) {
     const newActive = this.props.active
     if (prevProps.active !== newActive) {
       this.scrollTo(newActive);

--- a/index.js
+++ b/index.js
@@ -55,11 +55,10 @@ export default class Dots extends Component {
     activeBorderColor: "#FFF"
   };
 
-  componentWillReceiveProps({ active }) {
-    const oldActiveIndex = this.props.active;
-
-    if (oldActiveIndex !== active) {
-      this.scrollTo(active);
+  componentDidUpdate (prevProps, prevState, snapshot) {
+    const newActive = this.props.active
+    if (prevProps.active !== newActive) {
+      this.scrollTo(newActive);
     }
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/tsepeti/react-native-dots-pagination/issues/3, `componentWillReceiveProps` is not recommended for use, and `componentDidUpdate()` is suggested as a replacement for side-effects (https://fb.me/react-async-component-lifecycle-hooks)