### PR TITLE
fix: full width center

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,18 +126,21 @@ export default class Dots extends Component {
       width,
       paddingVertical,
       paddingHorizontal,
+      activeDotWidth,
+      activeBorderWidth,
       passiveDotWidth,
       marginHorizontal,
     } = this.props;
     const list = [...Array(length).keys()];
-    const scrollWidth = marginHorizontal * list.length * passiveDotWidth;
+    const activeWidth = (activeBorderWidth * 4) + activeDotWidth + paddingHorizontal;
+    const scrollWidth = activeWidth + ((list.length - 1) * passiveDotWidth) + (marginHorizontal * (list.length * 2));
 
     return (
       <View style={Styles.container}>
         <ScrollView
           ref={(el) => { this.scrollRef = el; }}
           style={{ width: width < scrollWidth ? width : scrollWidth }}
-          contentContainerStyle={{ paddingVertical, paddingHorizontal }}
+          contentContainerStyle={{ alignItems: 'center', paddingVertical, paddingHorizontal }}
           scalesPageToFit={scalesPageToFit}
           bounces={false}
           horizontal={true}


### PR DESCRIPTION
Hi @yasaricli 

This is suppose to center the dots horizontal correctly in full with(when the width > scrollWidth). I don't see any issues but there is probably a reason for the math that was being done before, I just can’t figure it out what it is.

I'm gonna use my fork because it works for me. I made the PR so you can consider it, but feel free to disregard it in case it does not make sense.

Thx a lot for the component 🖖 