### PR TITLE
Update doctoc due to security advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Paging as dots for react-native.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
   - [Quickstart](#quickstart)
   - [Using](#using)
 - [Props](#props)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^0.0.5",
+    "doctoc": "^2.2.1",
     "eslint": "^6.1.0",
     "ghooks": "^2.0.4"
   },
@@ -19,7 +20,6 @@
     }
   },
   "dependencies": {
-    "doctoc": "^1.4.0",
     "prop-types": "^15.7.2"
   },
   "keywords": [


### PR DESCRIPTION
## Summary of changes

- Update `doctoc` due to https://github.com/advisories/GHSA-cf4h-3jhx-xvhq
- Move doctoc to `devDependencies`
- Execute `npm run update-readme-toc` script