### PR TITLE
Accessibility: Adding pass-through for accessibility props.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,14 @@ export interface DotsProperties {
    * To adjust if the active dot should align with the x axis of the inactive dots
    */
   alignDotsOnXAxis?: boolean;
+  /**
+   * Set to true if you wish the dots to be reachable by screen reader. If true, you should supply an `acccessibilityLabel`. 
+   */
+  accessible?: boolean;
+  /**
+  * Label to be read by screen readers if the element is accessible. Should indicate to the user that there is swipeable content on the page, and which panel they are currently on.
+  */
+  accessibilityLabel?: string
 }
 
 export default class Dots extends Component<DotsProperties> {}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ export default class Dots extends Component {
 
       // events
       onScrollTo: PropTypes.func,
+
+      // accessibility
+      accessible: PropTypes.bool,
+      accessibilityLabel: PropTypes.string
     };
   }
 
@@ -61,6 +65,9 @@ export default class Dots extends Component {
     onScrollTo() {
       // this function on change index.
     },
+
+    accessible: false,
+    accessibilityLabel: ''
   };
 
   componentDidUpdate(prevProps) {
@@ -143,6 +150,8 @@ export default class Dots extends Component {
       activeBorderWidth,
       passiveDotWidth,
       marginHorizontal,
+      accessible,
+      accessibilityLabel
     } = this.props;
     const list = [...Array(length).keys()];
     const activeWidth =
@@ -153,7 +162,7 @@ export default class Dots extends Component {
       marginHorizontal * (list.length * 2);
 
     return (
-      <View style={Styles.container}>
+      <View style={Styles.container} accessible={accessible} accessibilityLabel={accessibilityLabel}>
         <ScrollView
           ref={(el) => {
             this.scrollRef = el;


### PR DESCRIPTION
Swiping presents accessibility challenges. One of these challenges is that screen reader users may not be aware that content is swipeable, as the visual indication (Dots, in this case), is invisible to them. 

This PR adds the React Native`accessible` and `accessibilityLabel` props for pass-through to the `<View>` container within the `<Dots>` element. This allows devs to make the dots accessible by screen reader, and to add an accessible label indicating that there is swipeable content on the page. 

Note that putting these properites on the pager view itself generally doesn't work, for the following reasons: 
1. It's semantically incorrect. Pager views don't, by themselves, tell sighted users that there is swipeable content. Generally there are other visual indicators (arrow buttons or dots). To maintain parity between the sighted and assistive experience, visual indicators for sighted users should also be what communicates to users of assistive technology that there is swipeable content. 
2. VoiceOver, on iOS, will treat any element that has `accessible={true}` as a single element, and not read or allow a screen reader to access any content inside. So placing an `accessible` prop and `accessibilityLabel` on the pager view itself results in loss of access to the content within the pager for users of assistive technology.

Adding an accessible label to the `<Dots>` element is a superior solution. And while it can already be done by adding a wrapper `<View>` around the `<Dots>` package, that results in an unnecessary `<View>` in the page hierarchy. This PR allows adding accessibility props without adding an additional `<View>`. 